### PR TITLE
Use full baseURL to make sure data is parsed correctly

### DIFF
--- a/layouts/shortcodes/plotly.html
+++ b/layouts/shortcodes/plotly.html
@@ -6,7 +6,7 @@
 
 <script>
   window.addEventListener('load', function() {
-    fetch('{{ .Get "data" | relURL }}')
+    fetch("{{ .Site.BaseURL }}" + "{{ .Get `data` }}")
       .then(response => response.json())
       .then(data => {
         const names = data.map(entry => entry.method);

--- a/layouts/shortcodes/tabulator.html
+++ b/layouts/shortcodes/tabulator.html
@@ -7,7 +7,7 @@
 
 <script>
   window.addEventListener('load', function() {
-    fetch('{{ .Get "data" | relURL }}')
+    fetch("{{ .Site.BaseURL }}" + "{{ .Get `data` }}")
       .then(response => response.json())
       .then(data => {
         window.tabulatorTables = window.tabulatorTables || {}; // Store multiple tables


### PR DESCRIPTION
Fix the issue of data not being parsed correctly with `relURL`