### PR TITLE
Fix leaderboard visualisation

### DIFF
--- a/layouts/shortcodes/plotly.html
+++ b/layouts/shortcodes/plotly.html
@@ -13,6 +13,12 @@
         const scores = data.map(entry => entry.score);
         const date = data.map(entry => entry.date);
 
+        // Formatted dates for visulisation
+        const formattedDates = date.map(d => {
+          const dt = new Date(d);
+          return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+        });
+
         // Identify SOTA points
         let sotaPoints = [];
         let maxScore = -Infinity;
@@ -103,6 +109,8 @@
             tickfont: {
               size: 13
             },
+            tickvals: date,
+            ticktext: formattedDates,
           },
           yaxis: {
             title: {

--- a/layouts/shortcodes/tabulator.html
+++ b/layouts/shortcodes/tabulator.html
@@ -34,7 +34,11 @@
           columns: [
             { title: "Team", field: "team", sorter: "string" },
             { title: "Method", field: "method", sorter: "string" },
-            { title: "Score", field: "score", sorter: "number" },
+            { title: "F1-Macro <span style='font-size: 1em; color: greem;'>(&#8593)</span>",
+              field: "score",
+              sorter: "number",
+              headerTooltip: "Higher is better"   
+            },
             { title: "Date", field: "date", sorter: "number" }
           ],
           height: "auto",


### PR DESCRIPTION
- Format dates to only show dates and not time in plotly
- Update column title from `Score` -> `F1-Macro` (↑)