### PR TITLE
Improve date formatting and fix click events

### DIFF
--- a/layouts/shortcodes/plotly.html
+++ b/layouts/shortcodes/plotly.html
@@ -1,5 +1,5 @@
 <!-- Chart container -->
-<div id="{{ .Get `id` }}" style="width:600%; max-width: 1200px; height:400px;"></div>
+<div id="{{ .Get `id` }}" style="width:600%; max-width: 1200px; height:550px;"></div>
 
 <!-- Plotly -->
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
@@ -103,14 +103,14 @@
           },
           autosize: false,
           width: 1200,
-          height: 450,
+          height: 600,
           xaxis: {
+            type: 'date',
             zeroline: false,
             tickfont: {
               size: 13
             },
-            tickvals: date,
-            ticktext: formattedDates,
+            tickformat: '%d %b %Y',
           },
           yaxis: {
             title: {

--- a/layouts/shortcodes/plotly.html
+++ b/layouts/shortcodes/plotly.html
@@ -12,6 +12,7 @@
         const names = data.map(entry => entry.method);
         const scores = data.map(entry => entry.score);
         const date = data.map(entry => entry.date);
+        const teams = data.map(entry => entry.team);
 
         // Formatted dates for visulisation
         const formattedDates = date.map(d => {
@@ -140,10 +141,15 @@
         chartDiv.on('plotly_click', function(eventData) {
           const clickedIndex = eventData.points[0].pointIndex;
           const clickedMethod = names[clickedIndex];
+          const clickedTeam = teams[clickedIndex];
 
           // Dispatch event for Tabulator
           window.dispatchEvent(new CustomEvent('plotly-click', { 
-            detail: { method: clickedMethod, chartId: "{{ .Get `id` }}" } 
+            detail: {
+              method: clickedMethod,
+              team: clickedTeam,
+              chartId: "{{ .Get `id` }}",
+            } 
           }));
 
           // Scroll to the correct table

--- a/layouts/shortcodes/tabulator.html
+++ b/layouts/shortcodes/tabulator.html
@@ -1,6 +1,9 @@
 <!-- Table container -->
 <div id="{{ .Get `id` }}-table" style="height:250px; width: auto;"></div>
 
+<!-- Load Luxon -->
+<script src="https://cdn.jsdelivr.net/npm/luxon@3/build/global/luxon.min.js"></script>
+
 <!-- Tabulator.js -->
 <link href="https://unpkg.com/tabulator-tables@5.3.4/dist/css/tabulator_bootstrap4.min.css" rel="stylesheet">
 <script src="https://unpkg.com/tabulator-tables@5.3.4/dist/js/tabulator.min.js"></script>
@@ -39,7 +42,13 @@
               sorter: "number",
               headerTooltip: "Higher is better"   
             },
-            { title: "Date", field: "date", sorter: "number" }
+            { title: "Date", field: "date", formatter:"datetime",
+              formatterParams:
+              { inputFormat: "iso",
+                outputFormat:"dd MMM yyyy",
+                invalidPlaceholder:"(invalid date)"
+              }
+            }
           ],
           height: "auto",
         });

--- a/layouts/shortcodes/tabulator.html
+++ b/layouts/shortcodes/tabulator.html
@@ -62,12 +62,17 @@
 
     // Listen for plotly-click event
     window.addEventListener('plotly-click', function(event) {
-      const { method, chartId } = event.detail;
+      const { method, team, chartId } = event.detail;
       const table = window.tabulatorTables[chartId];
-
+      
       if (table) {
         table.deselectRow();
-        const row = table.getRows().find(row => row.getData().method === method);
+        // const row = table.getRows().find(row => row.getData().method === method);
+        const row = table.getRows().find(row => {
+          const data = row.getData();
+          return data.method == method && data.team == team;
+        });
+
         if (row) {
           row.select();
           if (!hasScrolled) {

--- a/scripts/leaderboard_manager.py
+++ b/scripts/leaderboard_manager.py
@@ -162,7 +162,7 @@ class LeaderboardManager:
             # Round score to 4 digits
             input["score"] = round(input["score"], 4)
             # Parse date from ISO 8601 and convert to string
-            input["date"] = datetime.fromisoformat(input["date"]).strftime("%d-%b-%Y %H:%M:%S")
+            #input["date"] = datetime.fromisoformat(input["date"]).strftime("%d-%b-%Y %H:%M:%S")
             return input
 
         return [format(entry) for entry in leaderboard]


### PR DESCRIPTION
- Revert to using ISO datetime format in `leaderboard_manager` and format datetime in `plotly` and `tabulator`
- Click event was only using method name so it wasn't always selecting the right row. Using team and method both fixes that.